### PR TITLE
docs: fix contrast between lang name and code block (#54)

### DIFF
--- a/.vitepress/style/vars.css
+++ b/.vitepress/style/vars.css
@@ -17,6 +17,8 @@
   --vp-custom-block-tip-bg: rgba(18, 181, 157, 0.1);
   /* fix contrast on gray cards: used by --vp-c-text-2 */
   --vp-c-text-light-2: rgba(56 56 56 / 70%);
+  /* fix contrast: lang name on gray code block */
+  --vp-c-text-dark-3: rgba(180, 180, 180, 0.7);
 }
 
 .dark {
@@ -28,6 +30,8 @@
   --vp-custom-block-tip-bg: rgba(18, 181, 157, 0.1);
   /* fix contrast on gray cards: check the same above (this is the default) */
   --vp-c-text-dark-2: rgba(235, 235, 235, 0.60);
+  /* fix lang name: check the same above (this is the default) */
+  --vp-c-text-dark-3: rgba(235, 235, 235, 0.38);
 }
 
 /**


### PR DESCRIPTION
resolves #54
Cherry picked from https://github.com/vitest-dev/vitest/commit/08feae1eea7ae4b24967b46cdb280813febcd3d9