### PR TITLE
docs: fix `vi.fn` signature (#58)

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -1789,7 +1789,7 @@ Vitest provides utility functions to help you out through it's **vi** helper. Yo
 
 ### vi.fn
 
-- **Type:** `(fn: Function) => CallableMockInstance`
+- **Type:** `(fn?: Function) => CallableMockInstance`
 
   Creates a spy on a function, though can be initiated without one. Every time a function is invoked, it stores its call arguments, returns and instances. Also, you can manipulate its behavior with [methods](#mockinstance-methods).
   If no function is given, mock will return `undefined`, when invoked.


### PR DESCRIPTION
resolves #58
Cherry picked from https://github.com/vitest-dev/vitest/commit/0c2e323ee153e05307d6b7c35dbbbd739abaeeaa