### PR TITLE
docs: description for coverage `include` option (#72)

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -440,6 +440,13 @@ Used when `provider: 'c8'` is set. Coverage options are passed to [`c8`](https:/
 
 Used when `provider: 'istanbul'` is set.
 
+##### include
+
+- **Type:** `string[]`
+- **Default:** `['**']`
+
+List of files included in coverage as glob patterns
+
 ##### exclude
 
 - **Type:** `string[]`


### PR DESCRIPTION
resolves #72
Cherry picked from https://github.com/vitest-dev/vitest/commit/f3524602ccc678badaae6bc5c3945008d8cfd82a