### PR TITLE
docs: use `type: node` in launch configuration to debug (#74)

### DIFF
--- a/guide/debugging.md
+++ b/guide/debugging.md
@@ -14,7 +14,7 @@ To debug a test file in VSCode, create the following launch configuration.
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "pwa-node",
+      "type": "node",
       "request": "launch",
       "name": "Debug Current Test File",
       "autoAttachChildProcesses": true,


### PR DESCRIPTION
resolves #74
Cherry picked from https://github.com/vitest-dev/vitest/commit/5b8d6dbe75222aeeee897a3129222818c010bdd8