### PR TITLE
docs: `resolve.alias` link from docs (#83)

### DIFF
--- a/guide/index.md
+++ b/guide/index.md
@@ -35,7 +35,7 @@ Vitest requires Vite >=v2.7.10 and Node >=v14
 
 ## Configuring Vitest
 
-One of the main advantages of Vitest is its unified configuration with Vite. If present, `vitest` will read your root `vite.config.ts` to match with the plugins and setup as your Vite app. For example, your Vite [resolve.alias](https://vitejs.dev/config/#resolve-alias) and [plugins](https://vitejs.dev/guide/using-plugins.html) configuration will work out-of-the-box. If you want a different configuration during testing, you can:
+One of the main advantages of Vitest is its unified configuration with Vite. If present, `vitest` will read your root `vite.config.ts` to match with the plugins and setup as your Vite app. For example, your Vite [resolve.alias](https://vitejs.dev/config/shared-options.html#resolve-alias) and [plugins](https://vitejs.dev/guide/using-plugins.html) configuration will work out-of-the-box. If you want a different configuration during testing, you can:
 
 - Create `vitest.config.ts`, which will have the higher priority
 - Pass `--config` option to CLI, e.g. `vitest --config ./path/to/vitest.config.ts`


### PR DESCRIPTION
resolves #83
Cherry picked from https://github.com/vitest-dev/vitest/commit/8b84e1f056e7aaf1e5394f007cbc849e9b3f9f30