### PR TITLE
docs: small typo correction (#86)

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -263,7 +263,7 @@ Custom reporters for output. Reporters can be [a Reporter instance](https://gith
 - **Default:** `80`
 
 Truncate output diff lines up to `80` number of characters. You may wish to tune this,
-depending on you terminal window width.
+depending on your terminal window width.
 
 ### outputDiffLines
 


### PR DESCRIPTION
resolves #86
Cherry picked from https://github.com/vitest-dev/vitest/commit/802c67b63907f82ae28be317483f4c5a1e0d0ff5