### PR TITLE
docs: changed `toThrow` to `toThrowError` (#92)

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -249,7 +249,7 @@ When you use `test` in the top level of file, they are collected as part of the 
   describe('numberToCurrency', () => {
     describe('given an invalid number', () => {
       test('composed of non-numbers to throw error', () => {
-        expect(() => numberToCurrency('abc')).toThrow()
+        expect(() => numberToCurrency('abc')).toThrowError()
       })
     })
 
@@ -723,7 +723,7 @@ When you use `test` in the top level of file, they are collected as part of the 
   ```
 
   :::warning
-  A _deep equality_ will not be performed for `Error` objects. To test if something was thrown, use [`toThrow`](#tothrow) assertion.
+  A _deep equality_ will not be performed for `Error` objects. To test if something was thrown, use [`toThrowError`](#tothrowerror) assertion.
   :::
 
 ### toStrictEqual


### PR DESCRIPTION
resolves #92
Cherry picked from https://github.com/vitest-dev/vitest/commit/8ac3d47cfea527d4f57ffef1df27aa45d4c59326