### PR TITLE
docs: add info to toThrowError

#2262 (#137)

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -925,6 +925,8 @@ When you use `test` in the top level of file, they are collected as part of the 
 
 - **Type:** `(received: any) => Awaitable<void>`
 
+- **Alias:** `toThrow`
+
   `toThrowError` asserts if a function throws an error when it is called.
 
   For example, if we want to test that `getFruitStock('pineapples')` throws, we could write:
@@ -959,6 +961,10 @@ When you use `test` in the top level of file, they are collected as part of the 
     )
   })
   ```
+
+  :::tip
+    To test async functions, use in combination with [rejects](#rejects).
+  :::
 
 ### toMatchSnapshot
 


### PR DESCRIPTION
resolves #137
Cherry picked from https://github.com/vitest-dev/vitest/commit/532cc11b0c6f482dfde927c0ea25d62b0cb36706