### PR TITLE
docs(cli): suggest `--run` flag when using `vitest related` with `lint-staged` (#156)

### DIFF
--- a/guide/cli.md
+++ b/guide/cli.md
@@ -40,6 +40,17 @@ Useful to run with [`lint-staged`](https://github.com/okonet/lint-staged) or wit
 vitest related /src/index.ts /src/hello-world.js
 ```
 
+::: tip
+Don't forget that Vitest runs with enabled watch mode by default. If you are using tools like `lint-staged`, you  should also pass `--run` option, so that command can exit normally.
+
+```js
+// .lintstagedrc.js
+export default {
+  '*.{js,ts}': 'vitest related --run',
+}
+```
+:::
+
 ## Options
 
 | Options       |               |


### PR DESCRIPTION
resolves #156
Cherry picked from https://github.com/vitest-dev/vitest/commit/8c625d2a10f6a993c7253583bc065aa25c3cdf2a