### PR TITLE
docs: jest <29.0.0 has config printBasicPrototype set to true (#167)

### DIFF
--- a/guide/snapshot.md
+++ b/guide/snapshot.md
@@ -145,7 +145,7 @@ This does not really affect the functionality but might affect your commit diff 
 
 #### 2. `printBasicPrototype` is default to `false`
 
-Both Jest and Vitest's snapshots are powered by [`pretty-format`](https://github.com/facebook/jest/blob/main/packages/pretty-format). In Vitest we set `printBasicPrototype` default to `false` to provide a cleaner snapshot output, while in Jest it's `true` by default.
+Both Jest and Vitest's snapshots are powered by [`pretty-format`](https://github.com/facebook/jest/blob/main/packages/pretty-format). In Vitest we set `printBasicPrototype` default to `false` to provide a cleaner snapshot output, while in Jest <29.0.0 it's `true` by default.
 
 ```ts
 import { expect, test } from 'vitest'


### PR DESCRIPTION
resolves #167
Cherry picked from https://github.com/vitest-dev/vitest/commit/c29f1761ec0c281a6f45fa4379d3985899e51b63