### PR TITLE
revert: "docs: add instructions for debugging tests via terminal" (#179)

### DIFF
--- a/guide/debugging.md
+++ b/guide/debugging.md
@@ -4,21 +4,6 @@ title: Debugging | Guide
 
 # Debugging
 
-## Terminal
-
-To debug a test file without an IDE, you can use [`ndb`](https://github.com/GoogleChromeLabs/ndb). Just add a `debugger` statement anywhere in your code, and then run `ndb`:
-
-```sh
-# install ndb globally
-npm install -g ndb
-
-# alternatively, with yarn
-yarn global add ndb
-
-# run tests with debugger enabled
-ndb npm run test
-```
-
 ## VSCode
 
 To debug a test file in VSCode, create the following launch configuration.


### PR DESCRIPTION
resolves #179
Cherry picked from https://github.com/vitest-dev/vitest/commit/8ab33f1e97ccc1afbb7e46518d6f24eca8d075e1