### PR TITLE
docs: fix cac's dot notation reference link (#208)

### DIFF
--- a/guide/cli.md
+++ b/guide/cli.md
@@ -110,3 +110,5 @@ vitest related /src/index.ts /src/hello-world.js
 :::warning
 You cannot use this option with `--watch` enabled (enabled in dev by default).
 :::
+
+[cac's dot notation]: https://github.com/cacjs/cac#dot-nested-options

--- a/guide/index.md
+++ b/guide/index.md
@@ -153,5 +153,3 @@ Then go to the project where you are using Vitest and run `pnpm link --global vi
 ## Community
 
 If you have questions or need help, reach out to the community at [Discord](https://chat.vitest.dev) and [GitHub Discussions](https://github.com/vitest-dev/vitest/discussions).
-
-[cac's dot notation]: https://github.com/cacjs/cac#dot-nested-options


### PR DESCRIPTION
resolves #208
Cherry picked from https://github.com/vitest-dev/vitest/commit/051bb65719db567649b8a3c67390a665a3ab431d