### PR TITLE
docs: fix typo (#235)

### DIFF
--- a/guide/snapshot.md
+++ b/guide/snapshot.md
@@ -44,7 +44,7 @@ it('toUpperCase', () => {
 })
 ```
 
-Instead of creating a snapshot file, Vitest will modify the test file directory to update the snapshot as a string:
+Instead of creating a snapshot file, Vitest will modify the test file directly to update the snapshot as a string:
 
 ```ts
 import { expect, it } from 'vitest'


### PR DESCRIPTION
resolves #235
Cherry picked from https://github.com/vitest-dev/vitest/commit/97b1b4a36ab8f2112231e9e096fe1beaf519c288