### PR TITLE
docs: remove section about jasmine from migration page (#317)

### DIFF
--- a/guide/migration.md
+++ b/guide/migration.md
@@ -40,10 +40,6 @@ If you are only partially mocking a package, you might have previously used Jest
 + const { cloneDeep } = await vi.importActual('lodash/cloneDeep')
 ```
 
-**Jasmine API**
-
-Jest exports various [`jasmine`](https://jasmine.github.io/) globals (such as `jasmine.any()`). Any such instances will need to be migrated to [their Vitest counterparts](/api/).
-
 **Envs**
 
 Just like Jest, Vitest sets `NODE_ENV` to `test`, if it wasn't set before. Vitest also has a counterpart for `JEST_WORKER_ID` called `VITEST_POOL_ID` (always less than or equal to `maxThreads`), so if you rely on it, don't forget to rename it. Vitest also exposes `VITEST_WORKER_ID` which is a unique ID of a running worker - this number is not affected by `maxThreads`, and will increase with each created worker.


### PR DESCRIPTION
resolves #317
Cherry picked from https://github.com/vitest-dev/vitest/commit/1eb5eba4f91b778165d5868a18282fa99e44f00c